### PR TITLE
Rebrand from Rotaract District 3190 to Rotaract 3190

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Rotaract District 3190
+Copyright (c) 2018 Rotaract 3190
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ keep_files:
   - ".gitignore"
 
 # Site settings
-title: Rotaract District 3190
+title: Rotaract 3190
 subtitle: "Serve 2 Achieve | TeamPanthers"
 description: "RI District 3190 comprises of 8 revenue making districts namely Bangalore, Tumkur, Ramanagara, Malavalli, Mandya, Kolar, Chittoor and Thirupathi with around 140 clubs comprising of over 8000 members"
 url: "https://rotaract3190.org" # the base hostname & protocol for your site

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,14 +35,14 @@
 <meta name="twitter:image:src" content="{{ site.logo | prepend: site.baseurl | prepend: site.url }}">
 
 <meta name="keywords"
-    content="rotaract 3190 events, rotaract 3190 projects, rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190" />
+    content="rotaract 3190 events, rotaract 3190 projects, rotaract3190, rotaract, rotaract 3190, Rotaract 3190, community service, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190" />
 <meta name="author" content="ZeoSpec" />
 <meta name="subject" content="{{ site.subtitle }}">
-<meta name="copyright" content="Rotaract District 3190">
+<meta name="copyright" content="Rotaract 3190">
 <meta name="Classification" content="voluntary organization">
 <meta name="designer" content="ZeoSpec">
 <meta name="reply-to" content="admin@rotaract3190.org">
-<meta name="owner" content="Rotaract District 3190">
+<meta name="owner" content="Rotaract 3190">
 <meta name="url" content="https://rotaract3190.org">
 <meta name="identifier-URL" content="https://rotaract3190.org">
 <meta name="directory" content="submission">

--- a/clublocator.html
+++ b/clublocator.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Rotaract District 3190 | Club Locator</title>
+  <title>Rotaract 3190 | Club Locator</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
   integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
   crossorigin=""/>

--- a/icgf/index.html
+++ b/icgf/index.html
@@ -27,14 +27,14 @@
     <meta name="twitter:domain" content="https://rotaract3190.org">
     <meta name="twitter:image:src" content="images/og.png">
     <meta name="description" content="ROTACON 2019 - ICGF on youth Services #superheroes">
-    <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, icgf, youth service" />
+    <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, icgf, youth service" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="A Step towards the change!!!">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/milana2020/about.html
+++ b/milana2020/about.html
@@ -33,14 +33,14 @@
     <meta name="twitter:image:src" content="./milana_og.png">
     <meta name="description" content="About MILANA 2020 | The 42nd Annual District Rotaract Conference RID 3190">
     <meta name="keywords"
-        content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
+        content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="About MILANA 2020 | The 42nd Annual District Rotaract Conference">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/milana2020/contact.html
+++ b/milana2020/contact.html
@@ -35,14 +35,14 @@
     <meta name="twitter:image:src" content="./milana_og.png">
     <meta name="description" content="Contact MILANA 2020 | The 42nd Annual District Rotaract Conference RID 3190">
     <meta name="keywords"
-        content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
+        content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="Contact MILANA 2020 | The 42nd Annual District Rotaract Conference">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/milana2020/index.html
+++ b/milana2020/index.html
@@ -33,14 +33,14 @@
     <meta name="twitter:image:src" content="./milana_og.png">
     <meta name="description" content="MILANA 2020 | The 42nd Annual District Rotaract Conference RID 3190">
     <meta name="keywords"
-        content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
+        content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="MILANA 2020 | The 42nd Annual District Rotaract Conference">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/milana2020/schedule.html
+++ b/milana2020/schedule.html
@@ -35,14 +35,14 @@
     <meta name="twitter:image:src" content="./milana_og.png">
     <meta name="description" content="Schedule - MILANA 2020 | The 42nd Annual District Rotaract Conference RID 3190">
     <meta name="keywords"
-        content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
+        content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="Schedule - MILANA 2020 | The 42nd Annual District Rotaract Conference">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/milana2020/speakers.html
+++ b/milana2020/speakers.html
@@ -35,14 +35,14 @@
     <meta name="twitter:image:src" content="./milana_og.png">
     <meta name="description" content="Speakers - MILANA 2020 | The 42nd Annual District Rotaract Conference RID 3190">
     <meta name="keywords"
-        content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
+        content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="Speakers - MILANA 2020 | The 42nd Annual District Rotaract Conference">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/milana2020/tickets.html
+++ b/milana2020/tickets.html
@@ -38,11 +38,11 @@
         content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, MILANA 2020, Rotaract Conference" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="Tickets - MILANA 2020 | The 42nd Annual District Rotaract Conference">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/riy18-19/anveshana/index.html
+++ b/riy18-19/anveshana/index.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Anveshana</title>
+	<title>Rotaract 3190 | Anveshana</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Anveshana">
+	<meta property="og:title" content="Rotaract 3190 | Anveshana">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190 | Anveshana" />
+	<meta property="og:site_name" content="Rotaract 3190 | Anveshana" />
 	<meta property="og:image" content="../favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,19 +24,19 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Anveshana">
+	<meta name="twitter:title" content="Rotaract 3190 | Anveshana">
 	<meta name="twitter:description" content="ANVESHANA - The DLTW (District Leadership Training Workshop) is a Journey to discover true ROTARACTION. At the DLTW, rotaractors will learn not only the responsibilities of each role but also how best to execute them. It is also a great place to interact with their counterparts from other clubs and start interacting and share ideas, projects, joint projects, etc.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="../favicons/img_og.png">
-	<meta name="description" content="Rotaract District 3190: #rotaract #rid3190 #dltw">
+	<meta name="description" content="Rotaract 3190: #rotaract #rid3190 #dltw">
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, DLTW, ANVESHANA, leadership training" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="ThemeSINE, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -57,7 +57,7 @@
 	<link rel="icon" type="image/png" href="../favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | Anveshana" />
+	<meta name="application-name" content="Rotaract 3190 | Anveshana" />
 	<meta name="theme-color" content="#CF530B">
 	<meta name="msapplication-TileColor" content="#CF530B" />
 	<meta name="msapplication-TileImage" content="../favicons/mstile-144x144.png" />
@@ -1060,7 +1060,7 @@
 					<div class="section-header text-center">
 						<h2>Latest Posts</h2>
 						<p>
-							Check out Rotaract District 3190 Blog
+							Check out Rotaract 3190 Blog
 						</p>
 					</div>
 					<!--/.section-header-->

--- a/riy18-19/asta/index.html
+++ b/riy18-19/asta/index.html
@@ -32,11 +32,11 @@
         content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, ASTA, 3190 awards" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="ASTA - Rotaract Annual District Awards & Recognition 2018-19 | RID 3190">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/riy18-19/calendar.html
+++ b/riy18-19/calendar.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Calendar</title>
+	<title>Rotaract 3190 | Calendar</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
 	<meta property="og:title" content="Rotaract District | Calendar">
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190" />
+	<meta property="og:site_name" content="Rotaract 3190" />
 	<meta property="og:image" content="./favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,19 +24,19 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Calendar">
+	<meta name="twitter:title" content="Rotaract 3190 | Calendar">
 	<meta name="twitter:description" content="Public calendar for listing the events/project dates posted by Clubs, District team and public of Rotaract 3190">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="./favicons/img_og.png">
 	<meta name="description" content="Public calendar for listing the events/project dates posted by Clubs, District team and public of Rotaract 3190">
-	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
+	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | Calendar" />
+	<meta name="application-name" content="Rotaract 3190 | Calendar" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/clubs/index.html
+++ b/riy18-19/clubs/index.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Clubs</title>
+	<title>Rotaract 3190 | Clubs</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Clubs">
+	<meta property="og:title" content="Rotaract 3190 | Clubs">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190 | Clubs" />
+	<meta property="og:site_name" content="Rotaract 3190 | Clubs" />
 	<meta property="og:image" content="../favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,19 +24,19 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Clubs">
+	<meta name="twitter:title" content="Rotaract 3190 | Clubs">
 	<meta name="twitter:description" content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International spreading the Joy of Rotary amongst youngsters between ages of 18 and 30. Rotaract is part of the Global effort to bring peace and International understanding to the World. This effort starts at the community level but knows no limit in its outreach.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="../favicons/img_og.png">
 	<meta name="description" content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International spreading the Joy of Rotary amongst youngsters between ages of 18 and 30. Rotaract is part of the Global effort to bring peace and International understanding to the World. This effort starts at the community level but knows no limit in its outreach.">
-	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
+	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="../favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | EC 18-19" />
+	<meta name="application-name" content="Rotaract 3190 | EC 18-19" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="../favicons/mstile-144x144.png" />

--- a/riy18-19/clubs/zoneemerald.html
+++ b/riy18-19/clubs/zoneemerald.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Clubs</title>
+	<title>Rotaract 3190 | Clubs</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Clubs">
+	<meta property="og:title" content="Rotaract 3190 | Clubs">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190 | Clubs" />
+	<meta property="og:site_name" content="Rotaract 3190 | Clubs" />
 	<meta property="og:image" content="../favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,7 +24,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Clubs">
+	<meta name="twitter:title" content="Rotaract 3190 | Clubs">
 	<meta name="twitter:description" content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International spreading the Joy of Rotary amongst youngsters between ages of 18 and 30. Rotaract is part of the Global effort to bring peace and International understanding to the World. This effort starts at the community level but knows no limit in its outreach.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="../favicons/img_og.png">
@@ -32,11 +32,11 @@
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="../favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | EC 18-19" />
+	<meta name="application-name" content="Rotaract 3190 | EC 18-19" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="../favicons/mstile-144x144.png" />

--- a/riy18-19/clubs/zoneiris.html
+++ b/riy18-19/clubs/zoneiris.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Clubs</title>
+	<title>Rotaract 3190 | Clubs</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Clubs">
+	<meta property="og:title" content="Rotaract 3190 | Clubs">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190 | Clubs" />
+	<meta property="og:site_name" content="Rotaract 3190 | Clubs" />
 	<meta property="og:image" content="../favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,7 +24,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Clubs">
+	<meta name="twitter:title" content="Rotaract 3190 | Clubs">
 	<meta name="twitter:description" content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International spreading the Joy of Rotary amongst youngsters between ages of 18 and 30. Rotaract is part of the Global effort to bring peace and International understanding to the World. This effort starts at the community level but knows no limit in its outreach.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="../favicons/img_og.png">
@@ -32,11 +32,11 @@
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="../favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | EC 18-19" />
+	<meta name="application-name" content="Rotaract 3190 | EC 18-19" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="../favicons/mstile-144x144.png" />

--- a/riy18-19/clubs/zoneruby.html
+++ b/riy18-19/clubs/zoneruby.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Clubs</title>
+	<title>Rotaract 3190 | Clubs</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Clubs">
+	<meta property="og:title" content="Rotaract 3190 | Clubs">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190 | Clubs" />
+	<meta property="og:site_name" content="Rotaract 3190 | Clubs" />
 	<meta property="og:image" content="../favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,7 +24,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Clubs">
+	<meta name="twitter:title" content="Rotaract 3190 | Clubs">
 	<meta name="twitter:description" content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International spreading the Joy of Rotary amongst youngsters between ages of 18 and 30. Rotaract is part of the Global effort to bring peace and International understanding to the World. This effort starts at the community level but knows no limit in its outreach.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="../favicons/img_og.png">
@@ -32,11 +32,11 @@
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="../favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | EC 18-19" />
+	<meta name="application-name" content="Rotaract 3190 | EC 18-19" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="../favicons/mstile-144x144.png" />

--- a/riy18-19/clubs/zonesapphire.html
+++ b/riy18-19/clubs/zonesapphire.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Clubs</title>
+	<title>Rotaract 3190 | Clubs</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Clubs">
+	<meta property="og:title" content="Rotaract 3190 | Clubs">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190 | Clubs" />
+	<meta property="og:site_name" content="Rotaract 3190 | Clubs" />
 	<meta property="og:image" content="../favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,7 +24,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Clubs">
+	<meta name="twitter:title" content="Rotaract 3190 | Clubs">
 	<meta name="twitter:description" content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International spreading the Joy of Rotary amongst youngsters between ages of 18 and 30. Rotaract is part of the Global effort to bring peace and International understanding to the World. This effort starts at the community level but knows no limit in its outreach.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="../favicons/img_og.png">
@@ -32,11 +32,11 @@
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="../favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="../favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | EC 18-19" />
+	<meta name="application-name" content="Rotaract 3190 | EC 18-19" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="../favicons/mstile-144x144.png" />

--- a/riy18-19/comingsoon.html
+++ b/riy18-19/comingsoon.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190</title>
+	<title>Rotaract 3190</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190">
+	<meta property="og:title" content="Rotaract 3190">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190" />
+	<meta property="og:site_name" content="Rotaract 3190" />
 	<meta property="og:image" content="./favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,7 +24,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190">
+	<meta name="twitter:title" content="Rotaract 3190">
 	<meta name="twitter:description" content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International spreading the Joy of Rotary amongst youngsters between ages of 18 and 30. Rotaract is part of the Global effort to bring peace and International understanding to the World. This effort starts at the community level but knows no limit in its outreach.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="./favicons/img_og.png">
@@ -32,11 +32,11 @@
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190" />
+	<meta name="application-name" content="Rotaract 3190" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/contact.html
+++ b/riy18-19/contact.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190</title>
+	<title>Rotaract 3190</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190">
+	<meta property="og:title" content="Rotaract 3190">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190" />
+	<meta property="og:site_name" content="Rotaract 3190" />
 	<meta property="og:image" content="./favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,7 +24,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190">
+	<meta name="twitter:title" content="Rotaract 3190">
 	<meta name="twitter:description" content="Connect with Rotaract 3190 which has about 130+ clubs and 5000+ rotaractors.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="./favicons/img_og.png">
@@ -32,11 +32,11 @@
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | Contact" />
+	<meta name="application-name" content="Rotaract 3190 | Contact" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/dc-1819.html
+++ b/riy18-19/dc-1819.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Rotaract District 3190 | DC</title>
+    <title>Rotaract 3190 | DC</title>
     <meta property="fb:app_id" content="261774384602004" />
     <meta name="fb:page_id" content="529311780455210" />
-    <meta property="og:title" content="Rotaract District 3190 | DC 18-19">
+    <meta property="og:title" content="Rotaract 3190 | DC 18-19">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://rotaract3190.org">
     <meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
     <meta property="og:locality" content="Bangalore" />
     <meta property="og:region" content="Karnataka" />
     <meta property="og:country-name" content="INDIA" />
-    <meta property="og:site_name" content="Rotaract District 3190" />
+    <meta property="og:site_name" content="Rotaract 3190" />
     <meta property="og:image" content="./favicons/img_og.png" />
     <meta property="og:image:width" content="630" />
     <meta property="og:image:height" content="630" />
@@ -24,19 +24,19 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:creator" content="@Rotaract3190">
     <meta name="twitter:site" content="@Rotaract3190">
-    <meta name="twitter:title" content="Rotaract District 3190 | DC 18-19">
+    <meta name="twitter:title" content="Rotaract 3190 | DC 18-19">
     <meta name="twitter:description" content="Every Council needs a very important support in order to accomplish greater goals, one such support is the District Committee (DC Members). Meet our DC members for Rota year 2018 – 2019">
     <meta name="twitter:domain" content="https://rotaract3190.org">
     <meta name="twitter:image:src" content="./favicons/img_og.png">
     <meta name="description" content="Every Council needs a very important support in order to accomplish greater goals, one such support is the District Committee (DC Members). Meet our DC members for Rota year 2018 – 2019">
-    <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
+    <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="A Step towards the change!!!">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="Web Domus ITALIA, ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">
@@ -56,7 +56,7 @@
     <link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-    <meta name="application-name" content="Rotaract District 3190 | DC 18-19" />
+    <meta name="application-name" content="Rotaract 3190 | DC 18-19" />
     <meta name="theme-color" content="#000000">
     <meta name="msapplication-TileColor" content="#000000" />
     <meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/dhivara/index.html
+++ b/riy18-19/dhivara/index.html
@@ -33,11 +33,11 @@
     <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, rotafest, dhivara, rotacamp2019, kanakapura adventure camp" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="A Step towards the change!!!">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">

--- a/riy18-19/donors.html
+++ b/riy18-19/donors.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Rotaract District 3190 | Blood Bank</title>
+    <title>Rotaract 3190 | Blood Bank</title>
     <meta property="fb:app_id" content="261774384602004" />
     <meta name="fb:page_id" content="529311780455210" />
-    <meta property="og:title" content="Rotaract District 3190 | Blood Bank">
+    <meta property="og:title" content="Rotaract 3190 | Blood Bank">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://rotaract3190.org">
     <meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
     <meta property="og:locality" content="Bangalore" />
     <meta property="og:region" content="Karnataka" />
     <meta property="og:country-name" content="INDIA" />
-    <meta property="og:site_name" content="Rotaract District 3190" />
+    <meta property="og:site_name" content="Rotaract 3190" />
     <meta property="og:image" content="./favicons/img_og.png" />
     <meta property="og:image:width" content="630" />
     <meta property="og:image:height" content="630" />
@@ -24,19 +24,19 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:creator" content="@Rotaract3190">
     <meta name="twitter:site" content="@Rotaract3190">
-    <meta name="twitter:title" content="Rotaract District 3190 | Blood Bank">
+    <meta name="twitter:title" content="Rotaract 3190 | Blood Bank">
     <meta name="twitter:description" content="Rotaract is a Rotary-sponsored service club for young men and women ages 18 to 30. Rotaract clubs are either community or university based, and they’re sponsored by a local Rotary club. This makes them true “partners in service” and key members of the family of Rotary.As one of Rotary’s most significant and fastest-growing service programs, with more than 8,400 clubs in about 170 countries and geographical areas, Rotaract has become a worldwide phenomenon.">
     <meta name="twitter:domain" content="https://rotaract3190.org">
     <meta name="twitter:image:src" content="./favicons/img_og.png">
-    <meta name="description" content="Rotaract District 3190: #rotaract #rid3190">
+    <meta name="description" content="Rotaract 3190: #rotaract #rid3190">
     <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="A Step towards the change!!!">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="Web Domus ITALIA, ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">
@@ -56,7 +56,7 @@
     <link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-    <meta name="application-name" content="Rotaract District 3190 | Blood Bank" />
+    <meta name="application-name" content="Rotaract 3190 | Blood Bank" />
     <meta name="theme-color" content="#000000">
     <meta name="msapplication-TileColor" content="#000000" />
     <meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/eunice/index.html
+++ b/riy18-19/eunice/index.html
@@ -7,7 +7,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 
-	<title>Rotaract District 3190 | eunice</title>
+	<title>Rotaract 3190 | eunice</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
 	<meta property="og:title" content="eunice | 41st Annual Distirct Rotaract Conference">
@@ -34,11 +34,11 @@
 		content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, eunice, Rotaract Conference" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">

--- a/riy18-19/eventform.html
+++ b/riy18-19/eventform.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Event Submission</title>
+	<title>Rotaract 3190 | Event Submission</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Event Submission">
+	<meta property="og:title" content="Rotaract 3190 | Event Submission">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190" />
+	<meta property="og:site_name" content="Rotaract 3190" />
 	<meta property="og:image" content="./favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,19 +24,19 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Event Submission">
+	<meta name="twitter:title" content="Rotaract 3190 | Event Submission">
 	<meta name="twitter:description" content="Rotaract is a Rotary-sponsored service club for young men and women ages 18 to 30. Rotaract clubs are either community or university based, and they’re sponsored by a local Rotary club. This makes them true “partners in service” and key members of the family of Rotary.As one of Rotary’s most significant and fastest-growing service programs, with more than 8,400 clubs in about 170 countries and geographical areas, Rotaract has become a worldwide phenomenon.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="./favicons/img_og.png">
-	<meta name="description" content="Rotaract District 3190: #rotaract #rid3190">
-	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
+	<meta name="description" content="Rotaract 3190: #rotaract #rid3190">
+	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | Event Submission" />
+	<meta name="application-name" content="Rotaract 3190 | Event Submission" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/gallery/index.html
+++ b/riy18-19/gallery/index.html
@@ -2,40 +2,40 @@
 <html lang="en">
 
 <head>
-  <title>Rotaract District 3190 | Gallery</title>
+  <title>Rotaract 3190 | Gallery</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <meta property="fb:app_id" content="261774384602004" />
   <meta name="fb:page_id" content="529311780455210" />
-  <meta property="og:title" content="Rotaract District 3190 | Gallery">
+  <meta property="og:title" content="Rotaract 3190 | Gallery">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://rotaract3190.org">
   <meta property="og:email" content="admin@rotaract3190.org" />
   <meta property="og:locality" content="Bangalore" />
   <meta property="og:region" content="Karnataka" />
   <meta property="og:country-name" content="INDIA" />
-  <meta property="og:site_name" content="Rotaract District 3190 | Gallery" />
+  <meta property="og:site_name" content="Rotaract 3190 | Gallery" />
   <meta property="og:image" content="./black_og.png" />
   <meta property="og:image:width" content="630" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:description" content="Rotaract District 3190 | Gallery is archive of photos captured during projects meetings and service activities">
+  <meta property="og:description" content="Rotaract 3190 | Gallery is archive of photos captured during projects meetings and service activities">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:creator" content="@Rotaract3190">
   <meta name="twitter:site" content="@Rotaract3190">
-  <meta name="twitter:title" content="Rotaract District 3190 | Gallery">
-  <meta name="twitter:description" content="Rotaract District 3190 | Gallery is archive of photos captured during projects meetings and service activities">
+  <meta name="twitter:title" content="Rotaract 3190 | Gallery">
+  <meta name="twitter:description" content="Rotaract 3190 | Gallery is archive of photos captured during projects meetings and service activities">
   <meta name="twitter:domain" content="https://rotaract3190.org">
   <meta name="twitter:image:src" content="./black_og.png">
-  <meta name="description" content="Rotaract District 3190 | Gallery is archive of photos captured during projects meetings and service activities">
+  <meta name="description" content="Rotaract 3190 | Gallery is archive of photos captured during projects meetings and service activities">
   <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190" />
   <meta name="author" content="ZeoSpec" />
   <meta name="subject" content="A Step towards the change!!!">
-  <meta name="copyright" content="Rotaract District 3190">
+  <meta name="copyright" content="Rotaract 3190">
   <meta name="Classification" content="voluntary organization">
   <meta name="designer" content="ZeoSpec">
   <meta name="reply-to" content="admin@rotaract3190.org">
-  <meta name="owner" content="Rotaract District 3190">
+  <meta name="owner" content="Rotaract 3190">
   <meta name="url" content="https://rotaract3190.org">
   <meta name="identifier-URL" content="https://rotaract3190.org">
   <meta name="directory" content="submission">
@@ -43,7 +43,7 @@
   <meta http-equiv="cache-control" content="public" />
   <meta http-equiv="Expires" content="0">
 
-  <meta name="application-name" content="Rotaract District 3190 | Gallery" />
+  <meta name="application-name" content="Rotaract 3190 | Gallery" />
 
   <!-- Favicon  -->
   <link rel="icon" href="favicon.ico">

--- a/riy18-19/gallery/tigersday18.html
+++ b/riy18-19/gallery/tigersday18.html
@@ -2,40 +2,40 @@
 <html lang="en">
 
 <head>
-  <title>Rotaract District 3190 | Tigers Day '18</title>
+  <title>Rotaract 3190 | Tigers Day '18</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <meta property="fb:app_id" content="261774384602004" />
   <meta name="fb:page_id" content="529311780455210" />
-  <meta property="og:title" content="Rotaract District 3190 | Tigers Day '18">
+  <meta property="og:title" content="Rotaract 3190 | Tigers Day '18">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://rotaract3190.org">
   <meta property="og:email" content="admin@rotaract3190.org" />
   <meta property="og:locality" content="Bangalore" />
   <meta property="og:region" content="Karnataka" />
   <meta property="og:country-name" content="INDIA" />
-  <meta property="og:site_name" content="Rotaract District 3190 | Tigers Day '18" />
+  <meta property="og:site_name" content="Rotaract 3190 | Tigers Day '18" />
   <meta property="og:image" content="./black_og.png" />
   <meta property="og:image:width" content="630" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:description" content="Rotaract District 3190 | Tigers Day '18 had 32 Rotaractors from 8 clubs of Rotarct District 3190, participated in the international tiger day celebrations at Bannerghatta National Park and Biological park.">
+  <meta property="og:description" content="Rotaract 3190 | Tigers Day '18 had 32 Rotaractors from 8 clubs of Rotarct District 3190, participated in the international tiger day celebrations at Bannerghatta National Park and Biological park.">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:creator" content="@Rotaract3190">
   <meta name="twitter:site" content="@Rotaract3190">
-  <meta name="twitter:title" content="Rotaract District 3190 | Tigers Day '18">
-  <meta name="twitter:description" content="Rotaract District 3190 | Tigers Day '18 had 32 Rotaractors from 8 clubs of Rotarct District 3190, participated in the international tiger day celebrations at Bannerghatta National Park and Biological park.">
+  <meta name="twitter:title" content="Rotaract 3190 | Tigers Day '18">
+  <meta name="twitter:description" content="Rotaract 3190 | Tigers Day '18 had 32 Rotaractors from 8 clubs of Rotarct District 3190, participated in the international tiger day celebrations at Bannerghatta National Park and Biological park.">
   <meta name="twitter:domain" content="https://rotaract3190.org">
   <meta name="twitter:image:src" content="./black_og.png">
-  <meta name="description" content="Rotaract District 3190 | Tigers Day '18 had 32 Rotaractors from 8 clubs of Rotarct District 3190, participated in the international tiger day celebrations at Bannerghatta National Park and Biological park.">
+  <meta name="description" content="Rotaract 3190 | Tigers Day '18 had 32 Rotaractors from 8 clubs of Rotarct District 3190, participated in the international tiger day celebrations at Bannerghatta National Park and Biological park.">
   <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190" />
   <meta name="author" content="ZeoSpec" />
   <meta name="subject" content="A Step towards the change!!!">
-  <meta name="copyright" content="Rotaract District 3190">
+  <meta name="copyright" content="Rotaract 3190">
   <meta name="Classification" content="voluntary organization">
   <meta name="designer" content="ZeoSpec">
   <meta name="reply-to" content="admin@rotaract3190.org">
-  <meta name="owner" content="Rotaract District 3190">
+  <meta name="owner" content="Rotaract 3190">
   <meta name="url" content="https://rotaract3190.org">
   <meta name="identifier-URL" content="https://rotaract3190.org">
   <meta name="directory" content="submission">
@@ -43,7 +43,7 @@
   <meta http-equiv="cache-control" content="public" />
   <meta http-equiv="Expires" content="0">
 
-  <meta name="application-name" content="Rotaract District 3190 | Tigers Day '18" />
+  <meta name="application-name" content="Rotaract 3190 | Tigers Day '18" />
 
   <!-- Favicon  -->
   <link rel="icon" href="favicon.ico">

--- a/riy18-19/index.html
+++ b/riy18-19/index.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190</title>
+	<title>Rotaract 3190</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190">
+	<meta property="og:title" content="Rotaract 3190">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190" />
+	<meta property="og:site_name" content="Rotaract 3190" />
 	<meta property="og:image" content="./favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -25,7 +25,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190">
+	<meta name="twitter:title" content="Rotaract 3190">
 	<meta name="twitter:description"
 		content="Rotaract - an acronym for Rotary in Action is the Youth Wing of Rotary International.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
@@ -36,11 +36,11 @@
 		content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -60,7 +60,7 @@
 	<link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190" />
+	<meta name="application-name" content="Rotaract 3190" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/projectsubmission.html
+++ b/riy18-19/projectsubmission.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | Project Submission</title>
+	<title>Rotaract 3190 | Project Submission</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Project Submission">
+	<meta property="og:title" content="Rotaract 3190 | Project Submission">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190" />
+	<meta property="og:site_name" content="Rotaract 3190" />
 	<meta property="og:image" content="./favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,19 +24,19 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Project Submission">
+	<meta name="twitter:title" content="Rotaract 3190 | Project Submission">
 	<meta name="twitter:description" content="Rotaract is a Rotary-sponsored service club for young men and women ages 18 to 30. Rotaract clubs are either community or university based, and they’re sponsored by a local Rotary club. This makes them true “partners in service” and key members of the family of Rotary.As one of Rotary’s most significant and fastest-growing service programs, with more than 8,400 clubs in about 170 countries and geographical areas, Rotaract has become a worldwide phenomenon.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="./favicons/img_og.png">
-	<meta name="description" content="Rotaract District 3190: #rotaract #rid3190">
+	<meta name="description" content="Rotaract 3190: #rotaract #rid3190">
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190 | Project Submission" />
+	<meta name="application-name" content="Rotaract 3190 | Project Submission" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />
@@ -119,7 +119,7 @@
 				<div class="row">
 					<div class="col-lg-12 text-center">
 						<h3 class="section-subheading text-muted">The projects submitted will be evaluated, selected projects will be
-							featured on the landing page of Rotaract District 3190 official webiste, blog and email newsletter. Also will be
+							featured on the landing page of Rotaract 3190 official webiste, blog and email newsletter. Also will be
 							archieved under best projects section.</h3>
 					</div>
 				</div>

--- a/riy18-19/rotafest2018/index.html
+++ b/riy18-19/rotafest2018/index.html
@@ -6,10 +6,10 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-	<title>Rotaract District 3190 | Rotafest 2K18</title>
+	<title>Rotaract 3190 | Rotafest 2K18</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190 | Rotafest 2K18">
+	<meta property="og:title" content="Rotaract 3190 | Rotafest 2K18">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -17,7 +17,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190 | Rotafest 2K18" />
+	<meta property="og:site_name" content="Rotaract 3190 | Rotafest 2K18" />
 	<meta property="og:image" content="./assets/images/rotafest_logo_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -25,19 +25,19 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190 | Rotafest 2K18">
+	<meta name="twitter:title" content="Rotaract 3190 | Rotafest 2K18">
 	<meta name="twitter:description" content="ROTAFEST is one of the oldest fests of Bengaluru which originally was started to provide a platform for the people who have graduated out of college and cannot attend college fests.">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="./assets/images/rotafest_logo_og.png">
 	<meta name="description" content="ROTAFEST is one of the oldest fests of Bengaluru which originally was started to provide a platform for the people who have graduated out of college and cannot attend college fests.">
-	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, rotafest, prathibha" />
+	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, Rotaract 3190, community service, club service, rotaract bangalore, rotary3190, rotary district 3190, rotary 3190, rid3190, rotafest, prathibha" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -45,7 +45,7 @@
 	<meta http-equiv="cache-control" content="public" />
 	<meta http-equiv="Expires" content="0">
 
-	<meta name="application-name" content="Rotaract District 3190 | Rotafest 2K18" />
+	<meta name="application-name" content="Rotaract 3190 | Rotafest 2K18" />
 	<meta name="theme-color" content="#EE3268">
 
 	<!-- Favicon -->

--- a/riy18-19/samvruthi.html
+++ b/riy18-19/samvruthi.html
@@ -5,10 +5,10 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Rotaract District 3190 | samvruthi 2019</title>
+	<title>Rotaract 3190 | samvruthi 2019</title>
 	<meta property="fb:app_id" content="261774384602004" />
 	<meta name="fb:page_id" content="529311780455210" />
-	<meta property="og:title" content="Rotaract District 3190">
+	<meta property="og:title" content="Rotaract 3190">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="https://rotaract3190.org">
 	<meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
 	<meta property="og:locality" content="Bangalore" />
 	<meta property="og:region" content="Karnataka" />
 	<meta property="og:country-name" content="INDIA" />
-	<meta property="og:site_name" content="Rotaract District 3190" />
+	<meta property="og:site_name" content="Rotaract 3190" />
 	<meta property="og:image" content="./favicons/img_og.png" />
 	<meta property="og:image:width" content="630" />
 	<meta property="og:image:height" content="630" />
@@ -24,7 +24,7 @@
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:creator" content="@Rotaract3190">
 	<meta name="twitter:site" content="@Rotaract3190">
-	<meta name="twitter:title" content="Rotaract District 3190">
+	<meta name="twitter:title" content="Rotaract 3190">
 	<meta name="twitter:description" content="samvruthi 2019 | Mega Job Mela by Rotary & Rotaract 3190">
 	<meta name="twitter:domain" content="https://rotaract3190.org">
 	<meta name="twitter:image:src" content="./favicons/img_og.png">
@@ -32,11 +32,11 @@
 	<meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
 	<meta name="author" content="ZeoSpec" />
 	<meta name="subject" content="A Step towards the change!!!">
-	<meta name="copyright" content="Rotaract District 3190">
+	<meta name="copyright" content="Rotaract 3190">
 	<meta name="Classification" content="voluntary organization">
 	<meta name="designer" content="Web Domus ITALIA, ZeoSpec">
 	<meta name="reply-to" content="admin@rotaract3190.org">
-	<meta name="owner" content="Rotaract District 3190">
+	<meta name="owner" content="Rotaract 3190">
 	<meta name="url" content="https://rotaract3190.org">
 	<meta name="identifier-URL" content="https://rotaract3190.org">
 	<meta name="directory" content="submission">
@@ -56,7 +56,7 @@
 	<link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
 	<link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
 	<link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-	<meta name="application-name" content="Rotaract District 3190" />
+	<meta name="application-name" content="Rotaract 3190" />
 	<meta name="theme-color" content="#000000">
 	<meta name="msapplication-TileColor" content="#000000" />
 	<meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />

--- a/riy18-19/team.html
+++ b/riy18-19/team.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Rotaract District 3190 | Team</title>
+    <title>Rotaract 3190 | Team</title>
     <meta property="fb:app_id" content="261774384602004" />
     <meta name="fb:page_id" content="529311780455210" />
-    <meta property="og:title" content="Rotaract District 3190 | Team">
+    <meta property="og:title" content="Rotaract 3190 | Team">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://rotaract3190.org">
     <meta property="og:email" content="admin@rotaract3190.org" />
@@ -16,7 +16,7 @@
     <meta property="og:locality" content="Bangalore" />
     <meta property="og:region" content="Karnataka" />
     <meta property="og:country-name" content="INDIA" />
-    <meta property="og:site_name" content="Rotaract District 3190" />
+    <meta property="og:site_name" content="Rotaract 3190" />
     <meta property="og:image" content="./favicons/img_og.png" />
     <meta property="og:image:width" content="630" />
     <meta property="og:image:height" content="630" />
@@ -28,15 +28,15 @@
     <meta name="twitter:description" content="Rotaract is a Rotary-sponsored service club for young men and women ages 18 to 30. Rotaract clubs are either community or university based, and they’re sponsored by a local Rotary club. This makes them true “partners in service” and key members of the family of Rotary.As one of Rotary’s most significant and fastest-growing service programs, with more than 8,400 clubs in about 170 countries and geographical areas, Rotaract has become a worldwide phenomenon.">
     <meta name="twitter:domain" content="https://rotaract3190.org">
     <meta name="twitter:image:src" content="./favicons/img_og.png">
-    <meta name="description" content="Rotaract District 3190: #rotaract #rid3190">
+    <meta name="description" content="Rotaract 3190: #rotaract #rid3190">
     <meta name="keywords" content="rotaract3190, rotaract, rotaract 3190, rotaract district 3190, community service, international service, club service, rotaract club, rotaract bangalore, bangalore, rotary3190, rotary district 3190, rotary 3190, bangalore rotaract, , rotafest, rotaconference, rotacamp, rotatrek, blood bank, rotaract calendar" />
     <meta name="author" content="ZeoSpec" />
     <meta name="subject" content="A Step towards the change!!!">
-    <meta name="copyright" content="Rotaract District 3190">
+    <meta name="copyright" content="Rotaract 3190">
     <meta name="Classification" content="voluntary organization">
     <meta name="designer" content="Web Domus ITALIA, ZeoSpec">
     <meta name="reply-to" content="admin@rotaract3190.org">
-    <meta name="owner" content="Rotaract District 3190">
+    <meta name="owner" content="Rotaract 3190">
     <meta name="url" content="https://rotaract3190.org">
     <meta name="identifier-URL" content="https://rotaract3190.org">
     <meta name="directory" content="submission">
@@ -56,7 +56,7 @@
     <link rel="icon" type="image/png" href="favicons/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicons/favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="favicons/favicon-128.png" sizes="128x128" />
-    <meta name="application-name" content="Rotaract District 3190 | Team" />
+    <meta name="application-name" content="Rotaract 3190 | Team" />
     <meta name="theme-color" content="#000000">
     <meta name="msapplication-TileColor" content="#000000" />
     <meta name="msapplication-TileImage" content="favicons/mstile-144x144.png" />


### PR DESCRIPTION
Since we have Rotaract 3190 as a common across all social platforms, so to unify the SEO read across the site we are upgrading the brand name.